### PR TITLE
feat: Use secure ciphers only

### DIFF
--- a/mumble-server/murmur.ini
+++ b/mumble-server/murmur.ini
@@ -189,7 +189,7 @@ sslKey=set-by-install.sh
 # Note: Changing this option may impact the backwards compatibility of your
 # Murmur server, and can remove the ability for older Mumble clients to be able
 # to connect to it.
-#sslCiphers=EECDH+AESGCM:AES256-SHA:AES128-SHA
+sslCiphers=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256
 
 # If Murmur is started as root, which user should it switch to?
 # This option is ignored if Murmur isn't started with root privileges.


### PR DESCRIPTION
Change the ciphers to the same we are using for Nginx. They are secure according to the BSI and SSLLabs.